### PR TITLE
get testwatcher code working

### DIFF
--- a/advanced-selenium/Mod1/1.06/src/test/java/com/saucelabs/advancedselenium/SauceLabsTest.java
+++ b/advanced-selenium/Mod1/1.06/src/test/java/com/saucelabs/advancedselenium/SauceLabsTest.java
@@ -1,4 +1,4 @@
-package test.java.com.saucelabs.advancedselenium;
+package com.saucelabs.advancedselenium;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/advanced-selenium/Mod1/1.06/src/test/java/com/saucelabs/advancedselenium/SauceTestBase.java
+++ b/advanced-selenium/Mod1/1.06/src/test/java/com/saucelabs/advancedselenium/SauceTestBase.java
@@ -1,70 +1,72 @@
-package test.java.com.saucelabs.advancedselenium;
+package com.saucelabs.advancedselenium;
 
 import com.saucelabs.saucebindings.SauceOptions;
 import com.saucelabs.saucebindings.SauceSession;
 import io.github.bonigarcia.wdm.WebDriverManager;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.extension.TestWatcher;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.remote.RemoteWebDriver;
-import java.util.Collections
-
-@ExtendWith(SauceTestBase.SauceTestWatcher.class) // added in 1.06
 
 public class SauceTestBase {
-
     RemoteWebDriver driver = null;
     SauceSession session = null;
 
+    @RegisterExtension
+    public MyTestWatcher myTestWatcher = new MyTestWatcher();
+
+    @BeforeAll
+    public static void setExecution() {
+        // NOTE: This code is for convenience in this tutorial
+        // Normally this would be set in pom file or with IntelliJ
+        // Toggle this setting to determine whether tests run on SAUCE or LOCAL
+        System.setProperty("SELENIUM_PLATFORM", "LOCAL");
+    }
+
     @BeforeEach
     public void setUp(TestInfo testinfo) {  // added testinfo parameters in 1.06
-        System.setProperty("SELENIUM_PLATFORM"="SAUCE");
         ChromeOptions chromeOptions = new ChromeOptions();
-        if (System.getProperty("SELENIUM_PLATFORM") == null) {
+
+        if (System.getProperty("SELENIUM_PLATFORM").equals("LOCAL")) {
             WebDriverManager.chromedriver().setup();
+
             driver = new ChromeDriver(chromeOptions);
         } else if (System.getProperty("SELENIUM_PLATFORM").equals("SAUCE")) {
             SauceOptions sauceOptions = new SauceOptions(chromeOptions);
             sauceOptions.setName(testinfo.getDisplayName()); // added in 1.06
-            SauceSession sauceSession = new SauceSession(sauceOptions);
-            driver = sauceSession.start();
+
+            session = new SauceSession(sauceOptions);
+            driver = session.start();
         }
         else {
-            throw new RuntimeException("You have no environment variable set that specifies the local or remote host");
+            throw new RuntimeException("Set System Property 'SELENIUM_PLATFORM' to determine where test is run");
         }
     }
 
-
-    @AfterEach
-    public void endSession() {
-        if (session != null) {
-            session.stop(true);
-        } else if (driver != null) {
-            driver.quit();
-        }
-    }
-
-    public class SauceTestWatcher implements TestWatcher { // entire class added in 1.06
-        private SauceSession session;
-
-        public void setSession(SauceSession session) {
-            this.session = session;
+    public class MyTestWatcher implements TestWatcher { // entire class added in 1.06
+        @Override
+        public void testFailed(ExtensionContext context, Throwable cause) {
+            if (session != null) {
+                session.stop(false);
+            } else {
+                System.out.println("Test Failed!");
+                driver.quit();
+            }
         }
 
         @Override
-        protected void testFailed(ExtensionContext context, Throwable cause) {
-            session.stop(false);
+        public void testSuccessful(ExtensionContext context) {
+            if (session != null) {
+                session.stop(true);
+            } else {
+                System.out.println("Test Passed!");
+                driver.quit();
+            }
         }
-
-        @Override
-        protected void testSuccessful(ExtensionContext context) {
-            session.stop(true);
-        }
-
     }
 }

--- a/advanced-selenium/Mod1/1.06/src/test/java/com/saucelabs/advancedselenium/SeleniumTest.java
+++ b/advanced-selenium/Mod1/1.06/src/test/java/com/saucelabs/advancedselenium/SeleniumTest.java
@@ -1,4 +1,4 @@
-package test.java.com.saucelabs.advancedselenium;
+package com.saucelabs.advancedselenium;
 
 import io.github.bonigarcia.wdm.WebDriverManager;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
1. The package names shouldn't include `test.java.` (IntelliJ might have the wrong folder set as Test Source)
2. Needs to be `MyTestWatcher` instead of `SauceTestWatcher` because it has to handle both local & sauce use cases
3. I just found out that the advantage to this being an inner class is you don't have to set the values for the class to recognize the field values of the outer class!
4. We still need to use `RegisterExtension` even though the instance isn't actually used; code complains with `ExtendWith` probably because we are annotating the outer class and it doesn't like that
5. No AfterEach when using a TestWatcher
6. I put the System Property toggle in a static BeforeAll hook so people know it is special and isn't what you actually want in your project. Just a suggestion; feel free to put it back.